### PR TITLE
Fix Notification Cache Updates With Newly Discord Proposals

### DIFF
--- a/discord/src/lib.rs
+++ b/discord/src/lib.rs
@@ -224,6 +224,9 @@ impl Handler {
                                     }
                                 }
                             }
+                            if let Err(err) = db.insert_notif_cache_entry(&notif_cache) {
+                                log::error!("failed to insert notif cache {:#?}", err);
+                            }
                         }
                         Err(err) => {
                             log::error!("failed to load notif cache {:#?}", err);

--- a/discord/src/lib.rs
+++ b/discord/src/lib.rs
@@ -224,6 +224,12 @@ impl Handler {
                                     }
                                 }
                             }
+                            if let Err(err) = db.insert_governance(&governance_account) {
+                                log::error!("failed to isnert governance {:#?}", err);
+                            }
+                            // update the notif cache with the new proposal count
+                            notif_cache.last_proposals_count =
+                                governance_account.governance.proposals_count;
                             if let Err(err) = db.insert_notif_cache_entry(&notif_cache) {
                                 log::error!("failed to insert notif cache {:#?}", err);
                             }
@@ -376,8 +382,6 @@ impl Handler {
                                     }
                                 }
                             }
-                            notif_cache.last_proposals_count =
-                                governance_account.governance.proposals_count;
                             log::info!("checking for proposals to remove");
                             // remove any proposals which finished
                             for proposal in finished_proposals.iter() {


### PR DESCRIPTION
* When a new proposal is discovered, update the notification cache and persist to disk
* When current proposal counts differ from notif cache count tracking during proposal discovery, update notif cache before persisting to disk